### PR TITLE
Add minimal GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # TestCodex
 Ett litet projekt för att komma igång med Codex
+
+Denna repo innehåller en minimal webbsida som kan publiceras med **GitHub Pages**. Öppna `index.html` för att se ett litet exempel på interaktion utan några byggsteg.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <title>Codex Demo</title>
+    <style>
+        body { font-family: sans-serif; padding: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Denna hemsida är skapad med Codex</h1>
+    <label for="greeting-select">Välj hälsning:</label>
+    <select id="greeting-select">
+        <option value="">--Välj--</option>
+        <option value="hej">Hej</option>
+        <option value="hejdå">Hejdå</option>
+    </select>
+    <p id="response"></p>
+    <script>
+        const select = document.getElementById('greeting-select');
+        const response = document.getElementById('response');
+        select.addEventListener('change', () => {
+            if (select.value === 'hej') {
+                response.textContent = 'Tjena';
+            } else if (select.value === 'hejd\u00e5') {
+                response.textContent = 'Vi ses senare';
+            } else {
+                response.textContent = '';
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with a dropdown that displays text based on the option selected
- update README with info about the static demo page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881ec98b4bc832b82e5a8a30308a02c