### PR TITLE
Improve UI with emoji icons and space theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,27 @@
     <h1>Denna hemsida är skapad med Codex</h1>
     <p class="welcome">Välkommen till vår neonupplysta framtid!</p>
 
+    <div id="icon-select">
+        <label>Spelare 1:
+            <select id="icon1">
+                <option value="🤖">🤖</option>
+                <option value="👾">👾</option>
+                <option value="🚀">🚀</option>
+                <option value="🛸">🛸</option>
+                <option value="🛰">🛰</option>
+            </select>
+        </label>
+        <label>Spelare 2:
+            <select id="icon2">
+                <option value="🤖">🤖</option>
+                <option value="👾">👾</option>
+                <option value="🚀">🚀</option>
+                <option value="🛸">🛸</option>
+                <option value="🛰">🛰</option>
+            </select>
+        </label>
+    </div>
+
     <div id="board">
         <div class="cell" data-index="0"></div>
         <div class="cell" data-index="1"></div>

--- a/style.css
+++ b/style.css
@@ -4,6 +4,16 @@ body {
     background-color: #000;
     color: #0ff;
     font-family: 'Orbitron', sans-serif;
+    background: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.3) 1px, tra
+nsparent 2px),
+                radial-gradient(circle at 40% 60%, rgba(255,255,255,0.3) 1px, tra
+nsparent 2px),
+                radial-gradient(circle at 80% 30%, rgba(255,255,255,0.3) 1px, tra
+nsparent 2px),
+                radial-gradient(circle at 60% 80%, rgba(255,255,255,0.3) 1px, tra
+nsparent 2px),
+                linear-gradient(#000011, #000);
+    background-size: 200px 200px;
 }
 h1 {
     color: #f0f;
@@ -34,4 +44,35 @@ p.welcome {
 #status {
     margin-top: 20px;
     color: #f0f;
+}
+
+#icon-select {
+    margin-top: 20px;
+}
+#icon-select label {
+    margin-right: 10px;
+    font-size: 1.2em;
+}
+#icon-select select {
+    font-size: 1em;
+    background: #111;
+    color: #0ff;
+    border: 1px solid #0ff;
+    border-radius: 4px;
+}
+
+#reset {
+    margin-top: 20px;
+    padding: 10px 20px;
+    font-size: 1em;
+    color: #0ff;
+    background: linear-gradient(45deg, #ff0077, #00d4ff);
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 10px #0ff;
+    cursor: pointer;
+    text-transform: uppercase;
+}
+#reset:hover {
+    box-shadow: 0 0 20px #f0f;
 }

--- a/tictactoe.js
+++ b/tictactoe.js
@@ -4,8 +4,17 @@ let board = Array(9).fill(null);
 let gameOver = false;
 const statusDiv = document.getElementById('status');
 const resetBtn = document.getElementById('reset');
+const iconSelect1 = document.getElementById('icon1');
+const iconSelect2 = document.getElementById('icon2');
 
-statusDiv.textContent = `Spelare ${currentPlayer}s tur`;
+let playerIcons = { X: iconSelect1.value, O: iconSelect2.value };
+
+function updateIcons() {
+    playerIcons.X = iconSelect1.value;
+    playerIcons.O = iconSelect2.value;
+}
+
+statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]}s tur`;
 
 function checkWin(player) {
     const combos = [
@@ -20,17 +29,17 @@ function handleClick(e) {
     const idx = parseInt(e.target.dataset.index);
     if (board[idx] || gameOver) return;
     board[idx] = currentPlayer;
-    e.target.textContent = currentPlayer;
+    e.target.textContent = playerIcons[currentPlayer];
 
     if (checkWin(currentPlayer)) {
-        statusDiv.textContent = `Spelare ${currentPlayer} vinner!`;
+        statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]} vinner!`;
         gameOver = true;
     } else if (board.every(Boolean)) {
         statusDiv.textContent = 'Oavgjort!';
         gameOver = true;
     } else {
         currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
-        statusDiv.textContent = `Spelare ${currentPlayer}s tur`;
+        statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]}s tur`;
     }
 }
 
@@ -38,11 +47,20 @@ function resetGame() {
     board = Array(9).fill(null);
     gameOver = false;
     currentPlayer = 'X';
+    updateIcons();
     cells.forEach(cell => {
         cell.textContent = '';
     });
-    statusDiv.textContent = `Spelare ${currentPlayer}s tur`;
+    statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]}s tur`;
 }
 
 cells.forEach(cell => cell.addEventListener('click', handleClick));
 resetBtn.addEventListener('click', resetGame);
+iconSelect1.addEventListener('change', () => {
+    updateIcons();
+    statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]}s tur`;
+});
+iconSelect2.addEventListener('change', () => {
+    updateIcons();
+    statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]}s tur`;
+});


### PR DESCRIPTION
## Summary
- add dropdowns for each player to pick from five cyberpunk-style emojis
- style the background like space and restyle the reset button
- update JS logic to use selected emojis for gameplay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881f659efe8832b99a57f59f3b0fcb5