### PR TITLE
Add unique icon selection and background image

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,19 +1,10 @@
 body {
     margin: 0;
     padding: 40px;
-    background-color: #000;
     color: #0ff;
     font-family: 'Orbitron', sans-serif;
-    background: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.3) 1px, tra
-nsparent 2px),
-                radial-gradient(circle at 40% 60%, rgba(255,255,255,0.3) 1px, tra
-nsparent 2px),
-                radial-gradient(circle at 80% 30%, rgba(255,255,255,0.3) 1px, tra
-nsparent 2px),
-                radial-gradient(circle at 60% 80%, rgba(255,255,255,0.3) 1px, tra
-nsparent 2px),
-                linear-gradient(#000011, #000);
-    background-size: 200px 200px;
+    background: url("images/background.png") no-repeat center center fixed;
+    background-size: cover;
 }
 h1 {
     color: #f0f;

--- a/tictactoe.js
+++ b/tictactoe.js
@@ -14,6 +14,29 @@ function updateIcons() {
     playerIcons.O = iconSelect2.value;
 }
 
+function syncIconOptions() {
+    Array.from(iconSelect1.options).forEach(opt => {
+        opt.disabled = opt.value === iconSelect2.value;
+    });
+    Array.from(iconSelect2.options).forEach(opt => {
+        opt.disabled = opt.value === iconSelect1.value;
+    });
+}
+
+function ensureUniqueIcons(changedSelect) {
+    const otherSelect = changedSelect === iconSelect1 ? iconSelect2 : iconSelect1;
+    if (changedSelect.value === otherSelect.value) {
+        for (const option of otherSelect.options) {
+            if (option.value !== changedSelect.value) {
+                otherSelect.value = option.value;
+                break;
+            }
+        }
+    }
+    updateIcons();
+    syncIconOptions();
+}
+
 statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]}s tur`;
 
 function checkWin(player) {
@@ -48,6 +71,7 @@ function resetGame() {
     gameOver = false;
     currentPlayer = 'X';
     updateIcons();
+    syncIconOptions();
     cells.forEach(cell => {
         cell.textContent = '';
     });
@@ -57,10 +81,12 @@ function resetGame() {
 cells.forEach(cell => cell.addEventListener('click', handleClick));
 resetBtn.addEventListener('click', resetGame);
 iconSelect1.addEventListener('change', () => {
-    updateIcons();
+    ensureUniqueIcons(iconSelect1);
     statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]}s tur`;
 });
 iconSelect2.addEventListener('change', () => {
-    updateIcons();
+    ensureUniqueIcons(iconSelect2);
     statusDiv.textContent = `Spelare ${playerIcons[currentPlayer]}s tur`;
 });
+
+syncIconOptions();


### PR DESCRIPTION
## Summary
- apply `background.png` as the page background
- disable duplicate icons between players

## Testing
- `node -e "console.log('no tests')"`


------
https://chatgpt.com/codex/tasks/task_e_6881fac3a05c832b870496da6bd17e94