### PR TITLE
Update sliding puzzle controls

### DIFF
--- a/slidingPuzzle.js
+++ b/slidingPuzzle.js
@@ -43,24 +43,13 @@ function render() {
             div.classList.add('empty');
         } else {
             div.textContent = num;
-            div.draggable = true;
-            div.addEventListener('dragstart', dragStart);
+            div.addEventListener('click', () => moveTile(idx));
         }
         puzzle.appendChild(div);
     });
-    const emptyTile = document.querySelector('.tile.empty');
-    emptyTile.addEventListener('dragover', e => e.preventDefault());
-    emptyTile.addEventListener('drop', dropOnEmpty);
 }
 
-function dragStart(e) {
-    e.dataTransfer.setData('text/plain', e.target.dataset.index);
-    e.target.classList.add('dragging');
-}
-
-function dropOnEmpty(e) {
-    e.preventDefault();
-    const from = parseInt(e.dataTransfer.getData('text/plain'), 10);
+function moveTile(from) {
     const to = tiles.indexOf(null);
     const [fx, fy] = [from % size, Math.floor(from / size)];
     const [tx, ty] = [to % size, Math.floor(to / size)];

--- a/style.css
+++ b/style.css
@@ -106,11 +106,8 @@ p.welcome {
     justify-content: center;
     font-size: 2em;
     background: rgba(0, 0, 0, 0.6);
-    cursor: grab;
+    cursor: pointer;
     user-select: none;
-}
-.tile.dragging {
-    opacity: 0.5;
 }
 .tile.empty {
     border: none;


### PR DESCRIPTION
## Summary
- simplify sliding puzzle UI
- tiles now move on click instead of drag & drop
- adjust style for pointer cursor

## Testing
- `node --check slidingPuzzle.js`

------
https://chatgpt.com/codex/tasks/task_e_688213744ec8832b9a9be56270483cca