### PR TITLE
Add restart button for sliding puzzle

### DIFF
--- a/sliding-puzzle.html
+++ b/sliding-puzzle.html
@@ -11,6 +11,7 @@
     <p class="welcome">Ordna brickorna 1-15</p>
     <p><a class="home-link" href="index.html">Till startsidan</a></p>
     <div id="puzzle" class="puzzle-board"></div>
+    <button id="restart">Börja om</button>
     <script src="slidingPuzzle.js"></script>
 </body>
 </html>

--- a/slidingPuzzle.js
+++ b/slidingPuzzle.js
@@ -1,4 +1,5 @@
 const puzzle = document.getElementById('puzzle');
+const restartBtn = document.getElementById('restart');
 const size = 4;
 let tiles = [];
 
@@ -31,6 +32,9 @@ function init() {
     numbers.push(null);
     tiles = numbers;
     render();
+    if (restartBtn) {
+        restartBtn.style.display = 'none';
+    }
 }
 
 function render() {
@@ -57,7 +61,12 @@ function moveTile(from) {
         [tiles[from], tiles[to]] = [tiles[to], tiles[from]];
         render();
         if (checkSolved()) {
-            setTimeout(() => alert('Grattis! Du löste pusslet!'), 10);
+            setTimeout(() => {
+                alert('Grattis! Du löste pusslet!');
+                if (restartBtn) {
+                    restartBtn.style.display = 'block';
+                }
+            }, 10);
         }
     }
 }
@@ -67,6 +76,10 @@ function checkSolved() {
         if (tiles[i] !== i + 1) return false;
     }
     return true;
+}
+
+if (restartBtn) {
+    restartBtn.addEventListener('click', init);
 }
 
 init();

--- a/style.css
+++ b/style.css
@@ -91,6 +91,24 @@ p.welcome {
     box-shadow: 0 0 20px #f0f;
 }
 
+#restart {
+    margin-top: 20px;
+    padding: 10px 20px;
+    font-size: 1em;
+    color: #0ff;
+    background: linear-gradient(45deg, #ff0077, #00d4ff);
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 10px #0ff;
+    cursor: pointer;
+    text-transform: uppercase;
+    display: none;
+}
+
+#restart:hover {
+    box-shadow: 0 0 20px #f0f;
+}
+
 .puzzle-board {
     display: grid;
     grid-template-columns: repeat(4, 100px);


### PR DESCRIPTION
## Summary
- add a restart button to the sliding puzzle page
- style the restart button with cyberpunk theme
- allow restarting the puzzle with a new solvable mix

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688216dccbc8832b8d55f54894cab436