### PR TITLE
Add three.js sun-earth-moon visualisation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <div class="game-links">
         <a class="game-button" href="tictactoe.html">Tic-Tac-Toe</a>
         <a class="game-button" href="sliding-puzzle.html">Sliding Puzzle</a>
+        <a class="game-button" href="sol-jord-mane.html">Sol, Jord, Måne</a>
     </div>
 </body>
 </html>

--- a/sol-jord-mane.html
+++ b/sol-jord-mane.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="UTF-8">
+    <title>Sol, jord, måne</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <style>
+        #simulation-container { width: 100%; height: 500px; }
+        .controls { margin-top: 20px; }
+        .controls label { margin-right: 10px; }
+        .controls input[type="range"] { vertical-align: middle; }
+    </style>
+</head>
+<body>
+    <h1>Sol, jord, måne</h1>
+    <p class="welcome">Utforska solsystemets rytm</p>
+    <p><a class="home-link" href="index.html">Till startsidan</a></p>
+    <div id="simulation-container"></div>
+    <div class="controls">
+        <button id="playPause">Pausa</button>
+        <label>Hastighet
+            <input type="range" id="speed" min="0" max="5" step="0.1" value="1">
+        </label>
+        <label>Dag: <span id="dayCount">0</span></label>
+        <input type="range" id="timeline" min="0" max="3650" value="0" style="width:300px;">
+    </div>
+    <script src="https://unpkg.com/three@0.152.2/build/three.min.js"></script>
+    <script src="https://unpkg.com/three@0.152.2/examples/js/controls/OrbitControls.js"></script>
+    <script src="solJordMane.js"></script>
+</body>
+</html>

--- a/solJordMane.js
+++ b/solJordMane.js
@@ -1,0 +1,96 @@
+const container = document.getElementById('simulation-container');
+const playPauseBtn = document.getElementById('playPause');
+const speedSlider = document.getElementById('speed');
+const dayCountSpan = document.getElementById('dayCount');
+const timelineSlider = document.getElementById('timeline');
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(container.clientWidth, container.clientHeight);
+container.appendChild(renderer.domElement);
+
+const controls = new THREE.OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+
+camera.position.set(40, 20, 40);
+controls.update();
+
+const light = new THREE.PointLight(0xffffff, 2);
+scene.add(light);
+
+const sunMaterial = new THREE.MeshBasicMaterial({ color: 0xffff00 });
+const sunGeometry = new THREE.SphereGeometry(5, 32, 32);
+const sun = new THREE.Mesh(sunGeometry, sunMaterial);
+scene.add(sun);
+
+const earthPivot = new THREE.Object3D();
+scene.add(earthPivot);
+const earthMaterial = new THREE.MeshPhongMaterial({ color: 0x2233ff });
+const earth = new THREE.Mesh(new THREE.SphereGeometry(2, 32, 32), earthMaterial);
+earth.position.x = 15;
+earthPivot.add(earth);
+
+const moonPivot = new THREE.Object3D();
+earthPivot.add(moonPivot);
+const moonMaterial = new THREE.MeshPhongMaterial({ color: 0x888888 });
+const moon = new THREE.Mesh(new THREE.SphereGeometry(0.5, 32, 32), moonMaterial);
+moon.position.x = 4;
+moonPivot.add(moon);
+
+let lastTime = performance.now();
+let day = 0;
+let speedFactor = parseFloat(speedSlider.value); // days per second
+let paused = false;
+const maxDays = 3650;
+
+function animate(time) {
+    requestAnimationFrame(animate);
+    const delta = (time - lastTime) / 1000; // seconds
+    lastTime = time;
+
+    if (!paused) {
+        day += delta * speedFactor;
+        if (day > maxDays) {
+            day = maxDays;
+            paused = true;
+            playPauseBtn.textContent = 'Starta';
+        }
+        if (day < 0) day = 0;
+        timelineSlider.value = day.toFixed(1);
+    } else {
+        // when paused, day may be changed via slider
+        day = parseFloat(timelineSlider.value);
+    }
+
+    const earthAngle = (day / 365) * Math.PI * 2;
+    const moonAngle = (day / 30) * Math.PI * 2;
+    earthPivot.rotation.y = earthAngle;
+    moonPivot.rotation.y = moonAngle;
+
+    dayCountSpan.textContent = Math.floor(day);
+
+    controls.update();
+    renderer.render(scene, camera);
+}
+
+playPauseBtn.addEventListener('click', () => {
+    paused = !paused;
+    playPauseBtn.textContent = paused ? 'Starta' : 'Pausa';
+});
+
+speedSlider.addEventListener('input', () => {
+    speedFactor = parseFloat(speedSlider.value);
+});
+
+timelineSlider.addEventListener('input', () => {
+    day = parseFloat(timelineSlider.value);
+});
+
+window.addEventListener('resize', () => {
+    camera.aspect = container.clientWidth / container.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(container.clientWidth, container.clientHeight);
+});
+
+animate(performance.now());


### PR DESCRIPTION
## Summary
- link a new "Sol, Jord, Måne" page from index
- implement `sol-jord-mane.html` with controls
- add `solJordMane.js` using three.js for an interactive sun/earth/moon model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688224ea82c4832b8ee95c414ed00c69