### PR TITLE
Fix OrbitControls global import

### DIFF
--- a/lib/OrbitControls.js
+++ b/lib/OrbitControls.js
@@ -1,12 +1,12 @@
-import {
-	EventDispatcher,
-	MOUSE,
-	Quaternion,
-	Spherical,
-	TOUCH,
-	Vector2,
-	Vector3
-} from 'three';
+const {
+        EventDispatcher,
+        MOUSE,
+        Quaternion,
+        Spherical,
+        TOUCH,
+        Vector2,
+        Vector3
+} = THREE;
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).


### PR DESCRIPTION
## Summary
- adjust OrbitControls.js to rely on global `THREE`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68822b29dcd0832bace83588adb210c5