### PR TITLE
Improve moon visibility and simulation speed

### DIFF
--- a/sol-jord-mane.html
+++ b/sol-jord-mane.html
@@ -20,7 +20,7 @@
     <div class="controls">
         <button id="playPause">Pausa</button>
         <label>Hastighet
-            <input type="range" id="speed" min="0" max="5" step="0.1" value="1">
+            <input type="range" id="speed" min="0" max="100" step="1" value="10">
         </label>
         <label>Dag: <span id="dayCount">0</span></label>
         <input type="range" id="timeline" min="0" max="3650" value="0" style="width:300px;">

--- a/solJordMane.js
+++ b/solJordMane.js
@@ -20,6 +20,8 @@ controls.update();
 
 const light = new THREE.PointLight(0xffffff, 2);
 scene.add(light);
+const ambientLight = new THREE.AmbientLight(0x404040);
+scene.add(ambientLight);
 
 const sunMaterial = new THREE.MeshBasicMaterial({ color: 0xffff00 });
 const sunGeometry = new THREE.SphereGeometry(5, 32, 32);
@@ -35,14 +37,14 @@ earthPivot.add(earth);
 
 const moonPivot = new THREE.Object3D();
 earthPivot.add(moonPivot);
-const moonMaterial = new THREE.MeshPhongMaterial({ color: 0x888888 });
+const moonMaterial = new THREE.MeshPhongMaterial({ color: 0xdddddd });
 const moon = new THREE.Mesh(new THREE.SphereGeometry(0.5, 32, 32), moonMaterial);
 moon.position.x = 4;
 moonPivot.add(moon);
 
 let lastTime = performance.now();
 let day = 0;
-let speedFactor = parseFloat(speedSlider.value); // days per second
+let speedFactor = parseFloat(speedSlider.value) * 10; // days per second
 let paused = false;
 const maxDays = 3650;
 
@@ -82,7 +84,7 @@ playPauseBtn.addEventListener('click', () => {
 });
 
 speedSlider.addEventListener('input', () => {
-    speedFactor = parseFloat(speedSlider.value);
+    speedFactor = parseFloat(speedSlider.value) * 10;
 });
 
 timelineSlider.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- make speed slider allow faster values
- add ambient light and lighter moon
- multiply slider value for higher speed

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68822e6d3d9c832ba494a0ab9dd6a668