### PR TITLE
Fix slider jumping on Sol page and improve pause button style

### DIFF
--- a/style.css
+++ b/style.css
@@ -132,3 +132,26 @@ p.welcome {
     background: transparent;
     cursor: default;
 }
+
+/* Styling for Sol, jord, måne controls */
+#playPause {
+    margin-right: 10px;
+    padding: 10px 20px;
+    color: #0ff;
+    background: linear-gradient(45deg, #ff0077, #00d4ff);
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 10px #0ff;
+    cursor: pointer;
+    text-transform: uppercase;
+}
+
+#playPause:hover {
+    box-shadow: 0 0 20px #f0f;
+}
+
+#dayCount {
+    display: inline-block;
+    width: 4ch;
+    text-align: right;
+}


### PR DESCRIPTION
## Summary
- keep day counter width constant so the timeline slider doesn't jump
- add gradient style to the play/pause button

## Testing
- `node --check solJordMane.js`
- `node --check slidingPuzzle.js`
- `node --check tictactoe.js`


------
https://chatgpt.com/codex/tasks/task_e_6882313c0364832bacf1c0f9ad28f859