### PR TITLE
Improve orbit control layout

### DIFF
--- a/sol-jord-mane.html
+++ b/sol-jord-mane.html
@@ -24,9 +24,12 @@
         </label>
         <label>Dag: <span id="dayCount">0</span></label>
         <input type="range" id="timeline" min="0" max="3650" value="0" style="width:300px;">
-        <label><input type="checkbox" id="earthOrbit"> Rita jordens bana</label>
-        <label><input type="checkbox" id="moonOrbit"> Rita månens bana</label>
+        <br>
         <button id="clearOrbits">Radera banor</button>
+        <span class="orbit-options">
+            <label><input type="checkbox" id="earthOrbit"> Rita jordens bana</label>
+            <label><input type="checkbox" id="moonOrbit"> Rita månens bana</label>
+        </span>
     </div>
     <script src="lib/three.min.js"></script>
     <script type="module" src="solJordMane.js"></script>

--- a/style.css
+++ b/style.css
@@ -157,7 +157,7 @@ p.welcome {
 }
 #clearOrbits {
     margin-left: 10px;
-    padding: 5px 10px;
+    padding: 8px 16px;
     color: #0ff;
     background: linear-gradient(45deg, #ff0077, #00d4ff);
     border: none;
@@ -168,4 +168,12 @@ p.welcome {
 }
 #clearOrbits:hover {
     box-shadow: 0 0 20px #f0f;
+}
+
+.orbit-options {
+    margin-left: 10px;
+}
+
+.orbit-options label {
+    margin-right: 10px;
 }


### PR DESCRIPTION
## Summary
- move the Earth/Moon orbit checkboxes so they sit beside the clear button
- tweak the clear button styling
- add styles for the new checkbox container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68823b619d74832badf290765c955f3d