### PR TITLE
Replace slider with treaty radio buttons on Sweden map

### DIFF
--- a/sweden-map.html
+++ b/sweden-map.html
@@ -14,8 +14,14 @@
     <p><a class="home-link" href="index.html">Till startsidan</a></p>
 
     <div id="controls">
-        <label for="yearRange">År: <span id="yearLabel">1600</span></label>
-        <input type="range" id="yearRange" min="1600" max="1809" value="1600">
+        <fieldset>
+            <legend>Välj fred</legend>
+            <label><input type="radio" name="period" value="1617" checked>1617 Freden i Stolbova</label>
+            <label><input type="radio" name="period" value="1645">1645 Freden i Brömsebro</label>
+            <label><input type="radio" name="period" value="1658">1658 Freden i Roskilde</label>
+            <label><input type="radio" name="period" value="1721">1721 Freden i Nystad</label>
+            <label><input type="radio" name="period" value="1809">1809 Freden i Fredrikshamn</label>
+        </fieldset>
     </div>
     <div id="map"></div>
 

--- a/swedenMap.js
+++ b/swedenMap.js
@@ -14,7 +14,8 @@ Promise.all([
     swedenLayer = L.geoJSON(sweData, {style: {color: 'blue', weight: 1, fillOpacity: 0.4}});
     finlandLayer = L.geoJSON(finData, {style: {color: 'blue', weight: 1, fillOpacity: 0.4}});
     map.fitBounds(swedenLayer.getBounds());
-    updateMap(parseInt(document.getElementById('yearRange').value));
+    const initial = document.querySelector('input[name="period"]:checked').value;
+    updateMap(parseInt(initial));
 });
 
 function updateMap(year) {
@@ -27,7 +28,8 @@ function updateMap(year) {
     }
 }
 
-document.getElementById('yearRange').addEventListener('input', e => {
-    document.getElementById('yearLabel').textContent = e.target.value;
-    updateMap(parseInt(e.target.value));
+document.querySelectorAll('input[name="period"]').forEach(radio => {
+    radio.addEventListener('change', e => {
+        updateMap(parseInt(e.target.value));
+    });
 });


### PR DESCRIPTION
## Summary
- Replace year slider with radio buttons for major peace treaties
- Update map logic to react to selected treaty and toggle Finland layer accordingly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689494c0d1a8832ba9f3d0284eb0f4ba