### PR TITLE
Update Swedish historical boundaries

### DIFF
--- a/sweden-map.html
+++ b/sweden-map.html
@@ -2,25 +2,25 @@
 <html lang="sv">
 <head>
     <meta charset="UTF-8">
-    <title>Sveriges territorium 1600-1809</title>
+    <title>Sveriges gränser</title>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 </head>
 <body>
-    <h1>Sveriges territorium 1600-1809</h1>
+    <h1>Sveriges gränser</h1>
     <p class="welcome">Utforska Sveriges historiska gränser.</p>
     <p><a class="home-link" href="index.html">Till startsidan</a></p>
 
     <div id="controls">
         <fieldset>
-            <legend>Välj fred</legend>
-            <label><input type="radio" name="period" value="1617" checked>1617 Freden i Stolbova</label>
-            <label><input type="radio" name="period" value="1645">1645 Freden i Brömsebro</label>
-            <label><input type="radio" name="period" value="1658">1658 Freden i Roskilde</label>
-            <label><input type="radio" name="period" value="1721">1721 Freden i Nystad</label>
-            <label><input type="radio" name="period" value="1809">1809 Freden i Fredrikshamn</label>
+            <legend>Välj år</legend>
+            <label><input type="radio" name="period" value="1523" checked>1523</label>
+            <label><input type="radio" name="period" value="1617">1617</label>
+            <label><input type="radio" name="period" value="1658">1658</label>
+            <label><input type="radio" name="period" value="1809">1809</label>
+            <label><input type="radio" name="period" value="1905">1905</label>
         </fieldset>
     </div>
     <div id="map"></div>

--- a/swedenMap.js
+++ b/swedenMap.js
@@ -4,28 +4,46 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; OpenStreetMap'
 }).addTo(map);
 
-let swedenLayer;
-let finlandLayer;
+const boundaries = {
+    1523: [
+        [55.3, 12.7], [59.1, 12.5], [62.1, 17.4], [65.7, 23.0],
+        [67.8, 24.5], [69.0, 22.2], [69.8, 17.0], [68.9, 14.0],
+        [66.0, 12.0], [63.0, 8.0], [59.0, 11.5], [55.3, 12.7]
+    ],
+    1617: [
+        [55.3, 12.7], [59.1, 12.5], [62.1, 17.4], [65.7, 24.0],
+        [68.5, 31.0], [66.0, 33.5], [63.0, 32.0], [60.0, 29.0],
+        [58.0, 26.0], [56.0, 20.0], [55.3, 12.7]
+    ],
+    1658: [
+        [58.9, 5.5], [63.4, 7.8], [66.4, 11.0], [69.0, 14.5],
+        [69.5, 22.0], [63.0, 32.0], [58.0, 30.0], [55.5, 24.0],
+        [55.2, 20.0], [55.3, 13.0], [58.9, 5.5]
+    ],
+    1809: [
+        [55.3, 11.0], [59.0, 11.0], [62.2, 14.0], [65.0, 17.0],
+        [67.0, 19.0], [68.9, 21.5], [67.5, 24.0], [66.0, 23.5],
+        [63.8, 22.0], [60.0, 20.0], [56.0, 15.0], [55.3, 11.0]
+    ],
+    1905: [
+        [55.3, 11.0], [59.0, 11.0], [62.2, 14.0], [65.0, 17.0],
+        [67.0, 19.0], [68.9, 21.5], [67.5, 24.0], [66.0, 23.5],
+        [63.8, 22.0], [60.0, 20.0], [56.0, 15.0], [55.3, 11.0]
+    ]
+};
 
-Promise.all([
-    fetch('swe.geojson').then(r => r.json()),
-    fetch('fin.geojson').then(r => r.json())
-]).then(([sweData, finData]) => {
-    swedenLayer = L.geoJSON(sweData, {style: {color: 'blue', weight: 1, fillOpacity: 0.4}});
-    finlandLayer = L.geoJSON(finData, {style: {color: 'blue', weight: 1, fillOpacity: 0.4}});
-    map.fitBounds(swedenLayer.getBounds());
-    const initial = document.querySelector('input[name="period"]:checked').value;
-    updateMap(parseInt(initial));
-});
+let boundaryLayer;
 
 function updateMap(year) {
-    if (!swedenLayer || !finlandLayer) return;
-    if (!map.hasLayer(swedenLayer)) swedenLayer.addTo(map);
-    if (year < 1809) {
-        if (!map.hasLayer(finlandLayer)) finlandLayer.addTo(map);
-    } else {
-        if (map.hasLayer(finlandLayer)) map.removeLayer(finlandLayer);
+    if (boundaryLayer) {
+        map.removeLayer(boundaryLayer);
     }
+    boundaryLayer = L.polygon(boundaries[year], {
+        color: 'blue',
+        weight: 1,
+        fillOpacity: 0.4
+    }).addTo(map);
+    map.fitBounds(boundaryLayer.getBounds());
 }
 
 document.querySelectorAll('input[name="period"]').forEach(radio => {
@@ -33,3 +51,7 @@ document.querySelectorAll('input[name="period"]').forEach(radio => {
         updateMap(parseInt(e.target.value));
     });
 });
+
+const initial = document.querySelector('input[name="period"]:checked').value;
+updateMap(parseInt(initial));
+


### PR DESCRIPTION
## Summary
- Rename map page to "Sveriges gränser" and use year-based controls
- Display approximate Swedish boundaries for 1523, 1617, 1658, 1809 and 1905

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx eslint swedenMap.js` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6894a09e6a70832bb1b355c8cdcf36d3