### PR TITLE
Fix bullet removal on enemy hit and bump version

### DIFF
--- a/hotline-shooter.html
+++ b/hotline-shooter.html
@@ -11,7 +11,7 @@
   <h1>Hotline shooter</h1>
   <p class="welcome">Skjut dig genom nivån</p>
   <p><a class="home-link" href="index.html">Till startsidan</a></p>
-  <div class="version">v 1.2</div>
+  <div class="version">v 1.3</div>
   <canvas id="c" width="1200" height="760"></canvas>
   <div id="overlay"><div class="card">
     <div id="msg" style="font-size:28px;margin-bottom:10px"></div>

--- a/hotlineShooter.js
+++ b/hotlineShooter.js
@@ -165,11 +165,10 @@ function step(dt){
   tryMoveCircle(player,vx,vy,14);
 
   // bullets: substep continuous collision. First contact removes bullet.
-  for(let i=bullets.length-1;i>=0;i--){
+  bulletLoop: for(let i=bullets.length-1;i>=0;i--){
     const b=bullets[i];
     let remaining=dt;
-    let remove=false;
-    while(remaining>0 && !remove){
+    while(remaining>0){
       // handle immediate overlap before advancing
       let overlap=null, otype='';
       for(const e of enemies){
@@ -181,7 +180,9 @@ function step(dt){
         }
       }
       if(overlap){
-        hitEnemy(overlap,otype); remove=true; break;
+        hitEnemy(overlap,otype);
+        bullets.splice(i,1);
+        continue bulletLoop;
       }
 
       const step=Math.min(remaining,1/240); // ~4.17 ms => ~3 px step at 720 px/s
@@ -204,18 +205,21 @@ function step(dt){
       if(target){
         b.x = px + (nx - px) * bestT;
         b.y = py + (ny - py) * bestT;
-        hitEnemy(target,ttype); remove=true; break;
+        hitEnemy(target,ttype);
+        bullets.splice(i,1);
+        continue bulletLoop;
       }
 
       // no enemy hit this substep: wall or advance
       if(!insideAnyRect(nx,ny,1.5)){
-        wallThunk(); wallSpark(nx,ny,8); remove=true; break;
+        wallThunk(); wallSpark(nx,ny,8);
+        bullets.splice(i,1);
+        continue bulletLoop;
       }
 
       b.x=nx; b.y=ny; b.life-=step; remaining-=step;
-      if(b.life<=0){ remove=true; break; }
+      if(b.life<=0){ bullets.splice(i,1); continue bulletLoop; }
     }
-    if(remove){ bullets.splice(i,1); }
   }
 
   // enemies AI


### PR DESCRIPTION
## Summary
- stop bullets immediately after colliding with enemies or walls
- update Hotline shooter version string to v1.3

## Testing
- `node --check hotlineShooter.js`


------
https://chatgpt.com/codex/tasks/task_e_68963dbeb204832b8be7bd8d0ce030ec