### PR TITLE
Fix bullet damage and bump version to 1.5

### DIFF
--- a/hotline-shooter.html
+++ b/hotline-shooter.html
@@ -11,7 +11,7 @@
   <h1>Hotline shooter</h1>
   <p class="welcome">Skjut dig genom nivån</p>
   <p><a class="home-link" href="index.html">Till startsidan</a></p>
-  <div class="version">v 1.4</div>
+  <div class="version">v 1.5</div>
   <canvas id="c" width="1200" height="760"></canvas>
   <div id="overlay"><div class="card">
     <div id="msg" style="font-size:28px;margin-bottom:10px"></div>

--- a/hotlineShooter.js
+++ b/hotlineShooter.js
@@ -165,7 +165,7 @@ function step(dt){
   tryMoveCircle(player,vx,vy,14);
 
   // bullets: substep continuous collision. First contact removes bullet.
-  for(let i=bullets.length-1;i>=0;i--){
+  bulletLoop: for(let i=bullets.length-1;i>=0;i--){
     const b=bullets[i];
     let remaining=dt;
     while(remaining>0){
@@ -182,7 +182,7 @@ function step(dt){
       if(overlap){
         hitEnemy(overlap,otype);
         bullets.splice(i,1);
-        break;
+        continue bulletLoop;
       }
 
       const step=Math.min(remaining,1/240); // ~4.17 ms => ~3 px step at 720 px/s
@@ -207,18 +207,18 @@ function step(dt){
         b.y = py + (ny - py) * bestT;
         hitEnemy(target,ttype);
         bullets.splice(i,1);
-        break;
+        continue bulletLoop;
       }
 
       // no enemy hit this substep: wall or advance
       if(!insideAnyRect(nx,ny,1.5)){
         wallThunk(); wallSpark(nx,ny,8);
         bullets.splice(i,1);
-        break;
+        continue bulletLoop;
       }
 
       b.x=nx; b.y=ny; b.life-=step; remaining-=step;
-      if(b.life<=0){ bullets.splice(i,1); break; }
+      if(b.life<=0){ bullets.splice(i,1); continue bulletLoop; }
     }
   }
 


### PR DESCRIPTION
## Summary
- stop bullets after first enemy contact so damage only applies once
- bump hotline shooter version to 1.5

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check hotlineShooter.js`


------
https://chatgpt.com/codex/tasks/task_e_68b08df70e10832bacdeda89fcdb162d